### PR TITLE
Fix: use stored country code instead of default in phone edit form

### DIFF
--- a/field.class.php
+++ b/field.class.php
@@ -115,7 +115,7 @@ class profile_field_phone extends profile_field_base {
                                 $this->inputname,
                                 format_string($this->field->name),
                                 $required,
-                                $CFG->country ?? null);
+                                $this->alpha2 ?? $CFG->country ?? null);
     }
 
     /**


### PR DESCRIPTION
### Problem
When editing a user profile, if the user already has a phone number stored, the form incorrectly displays the country code based on `$CFG->country`, instead of using the country code from the database. This leads to inconsistencies in the form display.

### Fix
This patch changes the logic so that:
- If the user **has not set** a phone number, the form will default to using the country code from `$CFG->country`, if available.
- If the user **has set** a phone number, the form will now correctly display the country code stored in the database, rather than using the platform default.

### Change
The change was made in the field.class.php file, within the edit_field_add() method, to correct the logic used for selecting the country code displayed in the form.

### Result
This ensures consistent and accurate representation of the user's phone number in the edit form, especially for international users.

### Testing
- [x] User without phone number → form shows code from `$CFG->country` if set.
- [x] User with phone number → form shows stored country code.