### PR TITLE
Fix CSV import failing for phone profile field

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'profilefield_phone';
-$plugin->release = '1.2.5';
-$plugin->version = 2026020500;
+$plugin->release = '1.2.6';
+$plugin->version = 2026020601;
 $plugin->requires = 2022112800;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION

The phone profile field could not be imported via CSV user upload.
When Moodle had a default country configured, get_data_from_string()
would treat the entire input (e.g. "+41791234501") as the phone number
and fill alpha2/code from the default country. This caused validation
to fail because the number contained the country prefix, resulting in
an incorrect digit count (e.g. 11 digits instead of expected 9).

Changes:
- Add parse_international_number() to properly split international
  formats (+41..., 0041..., 41...) into country code and number
- Add preprocess_string_data() to convert string input from CSV
  into the internal storage format (alpha2)-code-number
- Update edit_validate_field() to parse international formats before
  falling back to get_data_from_string(), ensuring validation and
  storage use the same parsing strategy
- Update set_user_data() to handle legacy data stored in display
  format from previous broken imports
- Add build_internal_format() helper to centralize format construction